### PR TITLE
EEPROM: - allow wpakey with up to 40 chars

### DIFF
--- a/libraries/board/board.h
+++ b/libraries/board/board.h
@@ -13,7 +13,7 @@
 #define VERSION_1               1          // original CUN
 #define VERSION_2               67         // original CUN
 #define VERSION                 "1.67"
-#define VERSION_OTA             "V01-67-00" // for OTA
+#define VERSION_OTA             "V01-67-01" // for OTA
 #define CUL_V3
 
 // Feature definitions

--- a/libraries/fncollection/fncollection.cpp
+++ b/libraries/fncollection/fncollection.cpp
@@ -98,10 +98,10 @@ void FNCOLLECTIONClass::ews(uint8_t p, String data, bool commit)
  
 String FNCOLLECTIONClass::ers(uint8_t p)
 {
-  char data[20]; //Max 20 Bytes
+  char data[EE_MAX_ENTRY_LEN];
   int len=0;
   unsigned char k = 1;
-  while(k != '\0' && len<19)   //Read until null character
+  while(k != '\0' && len< (EE_MAX_ENTRY_LEN - 1))   //Read until null character
   {    
     k=erb(p++);
     data[len++]=k;
@@ -165,8 +165,8 @@ void FNCOLLECTIONClass::read_eeprom(char *in)
     } else if(in[2] == 'N') { display_ee_ip4(EE_IP4_NTPSERVER);
     } else if(in[2] == 'o') { DH2(erb(EE_IP4_NTPOFFSET));
 #   ifdef ESP8266
-    } else if(in[2] == 's') { display_string(EE_WPA_SSID, EE_STR_LEN);
-    } else if(in[2] == 'k') { display_string(EE_WPA_KEY, EE_STR_LEN);
+    } else if(in[2] == 's') { display_string(EE_WPA_SSID, EE_SSID_LEN);
+    } else if(in[2] == 'k') { display_string(EE_WPA_KEY, EE_WPA_KEY_LEN);
     } else if(in[2] == 'D') { display_string(EE_NAME, EE_STR_LEN);
     } else if(in[2] == 'O') { display_ee_ip4(EE_OTA_SERVER);
 #   endif
@@ -241,7 +241,7 @@ void FNCOLLECTIONClass::write_eeprom(char *in)
 void FNCOLLECTIONClass::write_eeprom(char *in, bool commit)
 {
 #ifdef ESP8266
-  uint8_t hb[EE_STR_LEN], d = 0;
+  uint8_t hb[EE_MAX_ENTRY_LEN], d = 0;
 #else
   uint8_t hb[6], d = 0;
 #endif
@@ -262,8 +262,8 @@ void FNCOLLECTIONClass::write_eeprom(char *in, bool commit)
       ntp_gmtoff = hb[0];
 #endif
 #   ifdef ESP8266
-    } else if(in[2] == 's') { d=EE_STR_LEN; STRINGFUNC.fromchars(in+3,hb, EE_STR_LEN); addr=EE_WPA_SSID;
-    } else if(in[2] == 'k') { d=EE_STR_LEN; STRINGFUNC.fromchars(in+3,hb, EE_STR_LEN); addr=EE_WPA_KEY;
+    } else if(in[2] == 's') { d=EE_SSID_LEN; STRINGFUNC.fromchars(in+3,hb, EE_SSID_LEN); addr=EE_WPA_SSID;
+    } else if(in[2] == 'k') { d=EE_WPA_KEY_LEN; STRINGFUNC.fromchars(in+3,hb, EE_WPA_KEY_LEN); addr=EE_WPA_KEY;
     } else if(in[2] == 'D') {
 			d=EE_STR_LEN; STRINGFUNC.fromchars(in+3,hb, EE_STR_LEN); addr=EE_NAME;
 			uint8_t len = strlen((const char*)hb);

--- a/libraries/fncollection/fncollection.h
+++ b/libraries/fncollection/fncollection.h
@@ -72,12 +72,16 @@ extern FNCOLLECTIONClass FNcol;
 # define EE_IP4_NTPOFFSET    (EE_IP4_TCPLINK_PORT+2)
 # define EE_STR_LEN        20
 # ifdef ESP8266
+#   define EE_MAX_ENTRY_LEN  64
+#   define EE_WPA_KEY_LEN    EE_MAX_ENTRY_LEN
+#   define EE_SSID_LEN       32
 #   define EE_WPA_SSID       (EE_IP4_NTPOFFSET+1)
-#   define EE_WPA_KEY        (EE_WPA_SSID+EE_STR_LEN)
-#   define EE_NAME           (EE_WPA_KEY+EE_STR_LEN)
+#   define EE_WPA_KEY        (EE_WPA_SSID+EE_SSID_LEN)
+#   define EE_NAME           (EE_WPA_KEY+EE_WPA_KEY_LEN)
 #   define EE_OTA_SERVER     (EE_NAME+EE_STR_LEN)
 #   define EE_ETH_LAST       (EE_OTA_SERVER+4)
 # else
+#   define EE_MAX_ENTRY_LEN    EE_STR_LEN
 #   define EE_ETH_LAST       (EE_IP4_NTPOFFSET+1)
 # endif
 #else


### PR DESCRIPTION
My wpa key is longer then 20 characters and I struggled for a while with culfw.esp8266 until I realized the limit in the code.

I doubled it with this PR.

This is an incompatible change in regard to the EEPROM format. I was not sure if I should set the Version to 68 now or how to handle this properly.